### PR TITLE
fix(deps): Use open ended ranges for peer deps (#48)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
     "typescript": "^3.7.3"
   },
   "peerDependencies": {
-    "@storybook/addons": "^5.2.0",
-    "@storybook/react": "^5.2.0",
-    "styled-components": "^4.0.0"
+    "@storybook/addons": ">=5.2.0",
+    "@storybook/react": ">=5.2.0",
+    "styled-components": ">=4.0.0"
   },
   "keywords": [
     "storybook",


### PR DESCRIPTION
As recommended:
https://twitter.com/SemanticRelease/status/1249795728253353986

The addon seems to work fine with styled-components 5.2.0, too.